### PR TITLE
Pavan feature backend validation and job skill matching

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "jsonwebtoken": "^8.5.1",
     "mongoose": "^6.3.0",
     "swagger-jsdoc": "^6.2.1",
-    "swagger-ui-express": "^4.3.0"
+    "swagger-ui-express": "^4.3.0",
+    "validator": "^13.7.0"
   },
   "devDependencies": {
     "concurrently": "^7.1.0",

--- a/server/controllers/jobController.js
+++ b/server/controllers/jobController.js
@@ -2,6 +2,7 @@
 
 const asyncHandler = require('express-async-handler')
 const Job = require('../models/jobsModel')
+const Skill = require('../models/skillsModel')
 
 // @desc    Get Jobs for an authorized user
 // @route   GET /api/jobs
@@ -9,6 +10,31 @@ const Job = require('../models/jobsModel')
 const getJobs = asyncHandler(async (req, res) => {
   const jobs = await Job.find({ user: req.user.id })
   res.status(200).json(jobs)
+})
+
+// @desc    Get Job Matched Skill Ids for an authorized user
+// @route   GET /api/jobs/matches
+// @access  Private - req.user retreived from auth middleware
+const getJobMatches = asyncHandler(async (req, res) => {
+  const jobs = await Job.find({ user: req.user.id })
+  const skills = await Skill.find({ user: req.user.id })
+
+  // returns a JSON with the key the objectID for the job
+  // value is an array of matched skillIDs for that job
+  const matchedSkills = {}
+  for (const i in jobs) {
+    matchedSkills[jobs[i]._id] = []
+    for (const j in skills) {
+      if ('jobSkills' in jobs[i]) {
+        for (const k in jobs[i].jobSkills) {
+          if (jobs[i].jobSkills[k].includes(skills[j].skillName)) {
+            matchedSkills[jobs[i]._id].push(skills[j]._id)
+          }
+        }
+      }
+    }
+  }
+  res.status(200).json(matchedSkills)
 })
 
 // @desc    Create job for an authorized user
@@ -111,5 +137,6 @@ module.exports = {
   getJobs,
   setJob,
   updateJob,
-  deleteJob
+  deleteJob,
+  getJobMatches
 }

--- a/server/controllers/skillController.js
+++ b/server/controllers/skillController.js
@@ -12,7 +12,7 @@ const getSkills = asyncHandler(async (req, res) => {
   res.status(200).json(skills)
 })
 
-// @desc    Get Skills Matches for an authorized user
+// @desc    Get Skills Matched Job IDs for an authorized user
 // @route   GET /api/skills/matches
 // @access  Private req.user retrieved from auth middleware
 const getSkillMatches = asyncHandler(async (req, res) => {

--- a/server/controllers/skillController.js
+++ b/server/controllers/skillController.js
@@ -2,18 +2,44 @@
 
 const asyncHandler = require('express-async-handler')
 const Skill = require('../models/skillsModel')
+const Job = require('../models/jobsModel')
 
 // @desc    Get Skills for an authorized user
 // @route   GET /api/skills
-// @access  Private req.user retreived from auth middleware
+// @access  Private req.user retrieved from auth middleware
 const getSkills = asyncHandler(async (req, res) => {
   const skills = await Skill.find({ user: req.user.id })
   res.status(200).json(skills)
 })
 
+// @desc    Get Skills Matches for an authorized user
+// @route   GET /api/skills/matches
+// @access  Private req.user retrieved from auth middleware
+const getSkillMatches = asyncHandler(async (req, res) => {
+  const skills = await Skill.find({ user: req.user.id })
+  const jobs = await Job.find({ user: req.user.id })
+
+  // returns a JSON with the key the objectID for the skill
+  // value is an array of matched jobIDs for that skill
+  const matchedJobs = {}
+  for (const i in skills) {
+    matchedJobs[skills[i]._id] = []
+    for (const j in jobs) {
+      if ('jobSkills' in jobs[j]) {
+        for (const k in jobs[j].jobSkills) {
+          if (jobs[j].jobSkills[k].includes(skills[i].skillName)) {
+            matchedJobs[skills[i]._id].push(jobs[j]._id)
+          }
+        }
+      }
+    }
+  }
+  res.status(200).json(matchedJobs)
+})
+
 // @desc    Create skill for an authorized user
 // @route   POST /api/skills
-// @access  Private req.user retreived from auth middleware
+// @access  Private req.user retrieved from auth middleware
 const setSkill = asyncHandler(async (req, res) => {
   // validate required field is in body
   if (!req.body.skillName) {
@@ -36,7 +62,7 @@ const setSkill = asyncHandler(async (req, res) => {
 
 // @desc    Update skill for an authorized user given skill id param
 // @route   PUT /api/skills/:id
-// @access  Private - req.user retreived from auth middleware
+// @access  Private - req.user retrieved from auth middleware
 const updateSkill = asyncHandler(async (req, res) => {
   const skill = await Skill.findById(req.params.id)
 
@@ -67,7 +93,7 @@ const updateSkill = asyncHandler(async (req, res) => {
 
 // @desc    Delete skill for an authorized user given skill id param
 // @route   DELETE /api/skills/:id
-// @access  Private - req.user retreived from auth middleware
+// @access  Private - req.user retrieved from auth middleware
 const deleteSkill = asyncHandler(async (req, res) => {
   const skill = await Skill.findById(req.params.id)
 
@@ -97,5 +123,6 @@ module.exports = {
   getSkills,
   setSkill,
   updateSkill,
-  deleteSkill
+  deleteSkill,
+  getSkillMatches
 }

--- a/server/models/contactsModel.js
+++ b/server/models/contactsModel.js
@@ -1,4 +1,5 @@
 const mongoose = require('mongoose')
+const validator = require('validator')
 
 // schema for job contacts
 const contactSchema = mongoose.Schema(
@@ -20,8 +21,15 @@ const contactSchema = mongoose.Schema(
     },
     contactCompany: { type: String },
     contactJobTitle: { type: String },
-    contactPhone: { type: String },
-    contactEmail: { type: String }
+    contactPhone: {
+      type: String,
+      // eslint-disable-next-line no-useless-escape
+      match: [/^[\+]?[(]?[0-9]{3}[)]?[-\s\.]?[0-9]{3}[-\s\.]?[0-9]{4,6}$/im, 'please enter a valid phone number']
+    },
+    contactEmail: {
+      type: String,
+      validate: [validator.isEmail, 'invalid email']
+    }
   }
 )
 

--- a/server/models/jobsModel.js
+++ b/server/models/jobsModel.js
@@ -1,4 +1,5 @@
 const mongoose = require('mongoose')
+const validator = require('validator')
 
 // schema for jobs
 const jobSchema = mongoose.Schema(
@@ -27,10 +28,22 @@ const jobSchema = mongoose.Schema(
     jobBenefits: { type: [String] },
     jobLocation: { type: String },
     jobDescription: { type: String },
-    dateApplied: { type: Date },
-    dateResponse: { type: Date },
-    dateInterview: { type: Date },
-    dateOffer: { type: Date },
+    dateApplied: {
+      type: Date,
+      validate: [validator.isDate, 'invalid Date format']
+    },
+    dateResponse: {
+      type: Date,
+      validate: [validator.isDate, 'invalid Date format']
+    },
+    dateInterview: {
+      type: Date,
+      validate: [validator.isDate, 'invalid Date format']
+    },
+    dateOffer: {
+      type: Date,
+      validate: [validator.isDate, 'invalid Date format']
+    },
     appStatus: {
       type: String,
       enum: ['APPLIED', 'WAITING', 'INTERVIEW SCHEDULED', 'INTERVIEW DONE']

--- a/server/models/userModel.js
+++ b/server/models/userModel.js
@@ -1,4 +1,5 @@
 const mongoose = require('mongoose')
+const validator = require('validator')
 
 // schema for users
 const userSchema = mongoose.Schema({
@@ -6,7 +7,8 @@ const userSchema = mongoose.Schema({
   email: {
     type: String,
     required: [true, 'please add an email'],
-    unique: true
+    unique: true,
+    validate: [validator.isEmail, 'invalid email']
   },
   userName: {
     type: String,
@@ -17,7 +19,10 @@ const userSchema = mongoose.Schema({
     type: String,
     required: [true, 'please add a password']
   },
-  gradDate: { type: Date },
+  gradDate: {
+    type: Date,
+    validate: [validator.isDate, 'invalid Date format']
+  },
   realName: { type: String }
 })
 

--- a/server/routes/jobRoutes.js
+++ b/server/routes/jobRoutes.js
@@ -4,7 +4,8 @@ const {
   getJobs,
   setJob,
   updateJob,
-  deleteJob
+  deleteJob,
+  getJobMatches
 } = require('../controllers/jobController.js')
 const { protect } = require('../middleware/authMiddleware.js')
 /**
@@ -268,7 +269,26 @@ router.route('/').get(protect, getJobs).post(protect, setJob)
 *       401:
 *         description: Not Authorized
 */
+
+/**
+* @swagger
+* /jobs/matches:
+*   get:
+*     summary: Get skill id matches for all job skills - Need Auth
+*     tags: [Jobs]
+*     security:
+*       - BearerAuth: [read]
+*     responses:
+*       200:
+*         description: Success - JSON, keys are job ID, values are arrays of matched skillIDs
+*       401:
+*         description: Not Authorized
+*/
+
 // delete and update jobs
 router.route('/:id').delete(protect, deleteJob).put(protect, updateJob)
+
+// get job matches
+router.route('/matches').get(protect, getJobMatches)
 
 module.exports = router

--- a/server/routes/skillRoutes.js
+++ b/server/routes/skillRoutes.js
@@ -4,7 +4,8 @@ const {
   getSkills,
   setSkill,
   updateSkill,
-  deleteSkill
+  deleteSkill,
+  getSkillMatches
 } = require('../controllers/skillController.js')
 const { protect } = require('../middleware/authMiddleware.js')
 /**
@@ -151,7 +152,26 @@ router.route('/').get(protect, getSkills).post(protect, setSkill)
 *       401:
 *         description: Not Authorized
 */
+
+/**
+* @swagger
+* /skills/matches:
+*   get:
+*     summary: Get job id matches for all user skills - Need Auth
+*     tags: [Skills]
+*     security:
+*       - BearerAuth: [read]
+*     responses:
+*       200:
+*         description: Success - JSON, keys are skill ID, values are arrays of matched jobIDs
+*       401:
+*         description: Not Authorized
+*/
+
 // update aand delete skills
 router.route('/:id').delete(protect, deleteSkill).put(protect, updateSkill)
+
+// get skill matches
+router.route('/matches').get(protect, getSkillMatches)
 
 module.exports = router


### PR DESCRIPTION
1. Added schema validation for dates, phone numbers, and email
- email and date are validated using npm package validator (added to dependencies in package.json)
- phone number is validated using regex:
- /^[\+]?[(]?[0-9]{3}[)]?[-\s\.]?[0-9]{3}[-\s\.]?[0-9]{4,6}$/im
Valid formats:
(123) 456-7890
(123)456-7890
123-456-7890
123.456.7890
1234567890
+31636363634
075-63546725

2. Added routes to access both skill matches and job matches (not sure which would be better so added both)
- sending a GET to /api/**skills**/matches will return a JSON where the **keys are the skillIDs** for the user and the values are an array of the matching jobIDs for that user
- likewise sending a GET to /api/**jobs**/matches will return a JSON where the **keys are the jobIDs** for the user and the values are an array of the matching skillIDs for that user
- everything noted here is also updated in the swagger documentation as well for these routes
- See image example of a response for futher clarification
api/jobs/matches
![image](https://user-images.githubusercontent.com/76919989/167942408-5c9a8e6b-9726-46fc-a4fb-bf80ce430b26.png)
api/skills/matches
![image](https://user-images.githubusercontent.com/76919989/167942574-010b17c7-8e66-4f9a-84e9-cc73fd98fbfc.png)

