### PR TITLE
Alex feature expand job form and dashboard

### DIFF
--- a/client/src/components/routes/index.jsx
+++ b/client/src/components/routes/index.jsx
@@ -3,6 +3,7 @@ import { Routes, Route } from "react-router";
 import HomePage from "../../pages/home-page";
 import CreateAccountPage from "../../pages/create-account-page";
 import JobDashboard from "../../pages/job-dashboard-page/JobDashboard";
+import JobDetails from "../../pages/job-dashboard-page/JobDetails";
 import AddJob from "../../pages/job-dashboard-page/addJob";
 import SkillsDashboard from "../../pages/skills-dashboard-page";
 import AddSkillPage from "../../pages/skills-dashboard-page/add-skill-page";
@@ -13,6 +14,7 @@ const AllRoutes = ({ user }) => {
     { path: "/", component: <HomePage user={user} /> },
     { path: "/signup", component: <CreateAccountPage /> },
     { path: "/job-dashboard", component: <JobDashboard /> },
+    { path: "/job-dashboard/:jobId", component: <JobDetails /> },
     { path: "/add-job", component: <AddJob /> },
     { path: "/skills", component: <SkillsDashboard /> },
     { path: "/add-skill", component: <AddSkillPage /> },

--- a/client/src/pages/job-dashboard-page/JobDashboard.css
+++ b/client/src/pages/job-dashboard-page/JobDashboard.css
@@ -27,3 +27,8 @@
   background-color: #FDFEFD;
   font-size: small;
 }
+
+.form-label {
+  font-size: small;
+  color: #224e4b;
+}

--- a/client/src/pages/job-dashboard-page/JobDashboard.css
+++ b/client/src/pages/job-dashboard-page/JobDashboard.css
@@ -32,3 +32,7 @@
   font-size: small;
   color: #224e4b;
 }
+
+.form-padding {
+  padding-bottom: 5px;
+}

--- a/client/src/pages/job-dashboard-page/JobDashboard.js
+++ b/client/src/pages/job-dashboard-page/JobDashboard.js
@@ -103,7 +103,6 @@ function JobDashboard() {
           }
         });
         const json = await response.json();
-        console.log(json);
         let data = populateTableData(json);
         setJobs(data);
         setLoading(true);

--- a/client/src/pages/job-dashboard-page/JobDashboard.js
+++ b/client/src/pages/job-dashboard-page/JobDashboard.js
@@ -57,7 +57,20 @@ const columns = [{
       </button>
     )
   }
+}, {
+  editable: false,
+  formatter: (content, row) => {
+    return (
+      <button className='delete-button' onClick = {() => jobDetails(row.id)}>
+        More
+      </button>
+    )
+  }
 }];
+
+const jobDetails = (jobID) => {
+  window.location.href = `/job-dashboard/${jobID}`
+}
 
 const deleteJob = (jobId) => {
   if (window.confirm("Are you sure you want to delete this job?")) {

--- a/client/src/pages/job-dashboard-page/JobDetails.js
+++ b/client/src/pages/job-dashboard-page/JobDetails.js
@@ -8,6 +8,12 @@ function JobDetails() {
   const [loading, setLoading] = useState(false);
   const token = localStorage.getItem("token");
 
+  const onChange = (e) => {
+    const name = e.target.name;
+    const value = e.target.value;
+    setJob({ ...job, [name]: value });
+  };
+
   useEffect(() => {
     const fetchData = async () => {
       try {
@@ -44,10 +50,10 @@ function JobDetails() {
 					application: job.appLink,
 					type: job.jobType,
 					description: job.jobDescription,
-					applied: job.dateApplied,
-					response: job.dateResponse,
-					interview: job.dateInterview,
-					offer: job.dateOffer,
+					applied: job.dateApplied.slice(0, 10),
+					response: job.dateResponse.slice(0, 10),
+					interview: job.dateInterview.slice(0, 10),
+					offer: job.dateOffer.slice(0, 10),
 					status: job.appStatus,
 					next: job.nextSteps,
 					decision: job.decision
@@ -60,7 +66,7 @@ function JobDetails() {
 	return (
     <div className="add-job-padding">
 			{setLoading}
-      <h3 className="jobs-header-2">View Job</h3>
+      <h3 className="jobs-header-2">Job Details</h3>
       <Form>
         <Form.Group className="form-padding">
           <Form.Control required placeholder="Title" defaultValue={job.title} name="jobTitle"></Form.Control>
@@ -79,8 +85,8 @@ function JobDetails() {
         </Form.Group>
 
         <Form.Group className="form-padding">
-          <Form.Control required as="select" aria-label="Default select example" name="jobType">
-            <option value="">Type: </option>
+          <Form.Control required as="select" onChange={(e)=> onChange(e)} aria-label="Default select example" name="type">
+            <option value="" selected disabled>Type: {job.type}</option>
             <option value="INTERNSHIP">INTERNSHIP</option>
             <option value="FULLTIME">FULLTIME</option>
           </Form.Control>
@@ -93,30 +99,30 @@ function JobDetails() {
 
         <div style={{ color: "#5dbb79" }}>Dates</div>
         <Form.Group>
-          <Form.Control type="date" placeholder="Applied Date" name="dateApplied"></Form.Control>
+          <Form.Control type="date" placeholder="Applied Date" value={job.applied} name="dateApplied"></Form.Control>
         </Form.Group>
         <div className="form-label">Applied Date</div>
 
         <Form.Group>
-          <Form.Control type="date" placeholder="Response Date" name="dateResponse"></Form.Control>
+          <Form.Control type="date" placeholder="Response Date" value={job.response} name="dateResponse"></Form.Control>
         </Form.Group>
         <div className="form-label">Response Date</div>
 
         <Form.Group>
-          <Form.Control type="date" placeholder="Interview Date" name="dateInterview"></Form.Control>
+          <Form.Control type="date" placeholder="Interview Date" value={job.interview} name="dateInterview"></Form.Control>
         </Form.Group>
         <div className="form-label">Interview Date</div>
 
         <Form.Group>
-          <Form.Control type="date" placeholder="Offer Date" name="dateOffer"></Form.Control>
+          <Form.Control type="date" placeholder="Offer Date" value={job.offer} name="dateOffer"></Form.Control>
         </Form.Group>
         <div className="form-label">Offer Date</div>
         <br />
 
-        <div style={{ color: "#5dbb79" }}>Status</div>
+        <div style={{ color: "#5dbb79" }}>Process</div>
         <Form.Group className="form-padding">
-          <Form.Control as="select" aria-label="Default select example" name="appStatus">
-            <option value="">Status: </option>
+          <Form.Control required as="select" onChange={(e)=> onChange(e)} aria-label="Default select example" name="status">
+            <option value="" selected disabled>Status: {job.status}</option>
             <option value="APPLIED">APPLIED</option>
             <option value="WAITING">WAITING</option>
             <option value="INTERVIEW SCHEDULED">INTERVIEW SCHEDULED</option>

--- a/client/src/pages/job-dashboard-page/JobDetails.js
+++ b/client/src/pages/job-dashboard-page/JobDetails.js
@@ -62,23 +62,23 @@ function JobDetails() {
 			{setLoading}
       <h3 className="jobs-header-2">View Job</h3>
       <Form>
-        <Form.Group>
+        <Form.Group className="form-padding">
           <Form.Control required placeholder="Title" defaultValue={job.title} name="jobTitle"></Form.Control>
         </Form.Group>
 
-        <Form.Group>
+        <Form.Group className="form-padding">
           <Form.Control required placeholder="Company" defaultValue={job.company} name="jobCompany"></Form.Control>
         </Form.Group>
 
-        <Form.Group>
+        <Form.Group className="form-padding">
           <Form.Control placeholder="Location" defaultValue={job.location} name="jobLocation"></Form.Control>
         </Form.Group>
 
-        <Form.Group>
+        <Form.Group className="form-padding">
           <Form.Control placeholder="Link to Application" defaultValue={job.application} name="appLink"></Form.Control>
         </Form.Group>
 
-        <Form.Group>
+        <Form.Group className="form-padding">
           <Form.Control required as="select" aria-label="Default select example" name="jobType">
             <option value="">Type: </option>
             <option value="INTERNSHIP">INTERNSHIP</option>
@@ -114,7 +114,7 @@ function JobDetails() {
         <br />
 
         <div style={{ color: "#5dbb79" }}>Status</div>
-        <Form.Group>
+        <Form.Group className="form-padding">
           <Form.Control as="select" aria-label="Default select example" name="appStatus">
             <option value="">Status: </option>
             <option value="APPLIED">APPLIED</option>
@@ -124,12 +124,12 @@ function JobDetails() {
           </Form.Control>
         </Form.Group>
 
-        <Form.Group>
+        <Form.Group className="form-padding">
           <Form.Control placeholder="Next steps" defaultValue={job.next} name="nextSteps"></Form.Control>
         </Form.Group>
 
         
-        <Form.Group>
+        <Form.Group className="form-padding">
           <Form.Control placeholder="Decision" defaultValue={job.decision} name="decision"></Form.Control>
         </Form.Group>
         <br />

--- a/client/src/pages/job-dashboard-page/JobDetails.js
+++ b/client/src/pages/job-dashboard-page/JobDetails.js
@@ -1,0 +1,163 @@
+import React, { useState, useEffect } from 'react';
+import { Link } from "react-router-dom";
+import { Form, Button } from "react-bootstrap";
+import "./JobDashboard.css";
+
+function JobDetails() {
+	const [job, setJob] = useState({})
+  const [loading, setLoading] = useState(false);
+  const token = localStorage.getItem("token");
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const response = await fetch('/api/jobs', {
+          headers: {
+            "Authorization": `Bearer ${token}`  
+          }
+        });
+        const json = await response.json();
+        let data = populateTableData(json);
+        setJob(data);
+        setLoading(true);
+      } catch (error) {
+        console.log(error);
+      }
+    };
+
+    fetchData();
+  }, []);
+
+  const populateTableData = (json) => {
+		const windowUrl = window.location.pathname;
+		const id = windowUrl.split("/")[2];
+		let each;
+		
+    json.forEach(job => {
+			if (job._id === id) {
+				 each = 
+      	{ 
+					id: job._id,
+					title: job.jobTitle, 
+					company: job.jobCompany,
+					location: job.jobLocation,
+					application: job.appLink,
+					type: job.jobType,
+					description: job.jobDescription,
+					applied: job.dateApplied,
+					response: job.dateResponse,
+					interview: job.dateInterview,
+					offer: job.dateOffer,
+					status: job.appStatus,
+					next: job.nextSteps,
+					decision: job.decision
+      	}
+			}
+    });
+		return each;
+  }
+
+	return (
+    <div className="add-job-padding">
+			{setLoading}
+      <h3 className="jobs-header-2">View Job</h3>
+      <Form>
+        <Form.Group>
+          <Form.Control required placeholder="Title" defaultValue={job.title} name="jobTitle"></Form.Control>
+        </Form.Group>
+
+        <Form.Group>
+          <Form.Control required placeholder="Company" defaultValue={job.company} name="jobCompany"></Form.Control>
+        </Form.Group>
+
+        <Form.Group>
+          <Form.Control placeholder="Location" defaultValue={job.location} name="jobLocation"></Form.Control>
+        </Form.Group>
+
+        <Form.Group>
+          <Form.Control placeholder="Link to Application" defaultValue={job.application} name="appLink"></Form.Control>
+        </Form.Group>
+
+        <Form.Group>
+          <Form.Control required as="select" aria-label="Default select example" name="jobType">
+            <option value="">Type: </option>
+            <option value="INTERNSHIP">INTERNSHIP</option>
+            <option value="FULLTIME">FULLTIME</option>
+          </Form.Control>
+        </Form.Group>
+
+        <Form.Group>
+          <Form.Control placeholder="Description: skills, salary, and benefits as applicable" defaultValue={job.description} name="jobDescription"></Form.Control>
+        </Form.Group>
+        <br />
+
+        <div style={{ color: "#5dbb79" }}>Dates</div>
+        <Form.Group>
+          <Form.Control type="date" placeholder="Applied Date" name="dateApplied"></Form.Control>
+        </Form.Group>
+        <div className="form-label">Applied Date</div>
+
+        <Form.Group>
+          <Form.Control type="date" placeholder="Response Date" name="dateResponse"></Form.Control>
+        </Form.Group>
+        <div className="form-label">Response Date</div>
+
+        <Form.Group>
+          <Form.Control type="date" placeholder="Interview Date" name="dateInterview"></Form.Control>
+        </Form.Group>
+        <div className="form-label">Interview Date</div>
+
+        <Form.Group>
+          <Form.Control type="date" placeholder="Offer Date" name="dateOffer"></Form.Control>
+        </Form.Group>
+        <div className="form-label">Offer Date</div>
+        <br />
+
+        <div style={{ color: "#5dbb79" }}>Status</div>
+        <Form.Group>
+          <Form.Control as="select" aria-label="Default select example" name="appStatus">
+            <option value="">Status: </option>
+            <option value="APPLIED">APPLIED</option>
+            <option value="WAITING">WAITING</option>
+            <option value="INTERVIEW SCHEDULED">INTERVIEW SCHEDULED</option>
+            <option value="INTERVIEW DONE">INTERVIEW DONE</option>
+          </Form.Control>
+        </Form.Group>
+
+        <Form.Group>
+          <Form.Control placeholder="Next steps" defaultValue={job.next} name="nextSteps"></Form.Control>
+        </Form.Group>
+
+        
+        <Form.Group>
+          <Form.Control placeholder="Decision" defaultValue={job.decision} name="decision"></Form.Control>
+        </Form.Group>
+        <br />
+
+        {/* <div style={{ color: "#5dbb79" }}>Contact</div>
+        <Form.Group>
+          <Form.Control placeholder="Name" name="contactName" onChange={onChange}></Form.Control>
+        </Form.Group>
+
+        <Form.Group>
+          <Form.Control placeholder="Phone" name="contactPhone" onChange={onChange}></Form.Control>
+        </Form.Group>
+
+        <Form.Group>
+          <Form.Control placeholder="Email" name="contactEmail" onChange={onChange}></Form.Control>
+        </Form.Group>
+        <br /> */}
+
+        <Button type="submit">Add</Button>
+        <Link to="/job-dashboard">
+          <Button style={{ marginLeft: "0.5rem" }}>Cancel</Button>
+        </Link>
+        <br />
+        <br />
+      </Form>
+    </div>
+  );
+}
+
+export default JobDetails
+

--- a/client/src/pages/job-dashboard-page/JobDetails.js
+++ b/client/src/pages/job-dashboard-page/JobDetails.js
@@ -14,6 +14,26 @@ function JobDetails() {
     setJob({ ...job, [name]: value });
   };
 
+  const onSubmit = (e) => {
+    e.preventDefault();
+    e.persist();
+    const token = localStorage.getItem("token");
+
+    // PUT to DB
+    fetch(`/api/jobs/${job._id}`, {
+      method: 'PUT',
+      headers: {
+        "Content-Type": "application/json",
+        "Authorization": `Bearer ${token}`
+      },
+      body: JSON.stringify(job)
+    }).then(onSubmitSuccess()).catch(err => console.error(err))
+  }
+
+  const onSubmitSuccess = () => {
+    window.location.href = "/job-dashboard"
+  }
+
   useEffect(() => {
     const fetchData = async () => {
       try {
@@ -43,19 +63,19 @@ function JobDetails() {
 			if (job._id === id) {
 				 each = 
       	{ 
-					id: job._id,
-					title: job.jobTitle, 
-					company: job.jobCompany,
-					location: job.jobLocation,
-					application: job.appLink,
-					type: job.jobType,
-					description: job.jobDescription,
-					applied: job.dateApplied.slice(0, 10),
-					response: job.dateResponse.slice(0, 10),
-					interview: job.dateInterview.slice(0, 10),
-					offer: job.dateOffer.slice(0, 10),
-					status: job.appStatus,
-					next: job.nextSteps,
+					_id: job._id,
+					jobTitle: job.jobTitle, 
+					jobCompany: job.jobCompany,
+					jobLocation: job.jobLocation,
+					appLink: job.appLink,
+					jobType: job.jobType,
+					jobDescription: job.jobDescription,
+					dateApplied: (job.dateApplied === undefined || job.dateApplied === null) ? undefined : job.dateApplied.slice(0, 10),
+					dateResponse: (job.dateResponse === undefined || job.dateResponse === null) ? undefined : job.dateResponse.slice(0, 10),
+					dateInterview: (job.dateInterview === undefined || job.dateInterview === null) ? undefined : job.dateInterview.slice(0, 10),
+					dateOffer: (job.dateOffer === undefined || job.dateOffer === null) ? undefined : job.dateOffer.slice(0, 10),
+					appStatus: job.appStatus,
+					nextSteps: job.nextSteps,
 					decision: job.decision
       	}
 			}
@@ -67,62 +87,72 @@ function JobDetails() {
     <div className="add-job-padding">
 			{setLoading}
       <h3 className="jobs-header-2">Job Details</h3>
-      <Form>
+      <Form onSubmit={onSubmit}>
         <Form.Group className="form-padding">
-          <Form.Control required placeholder="Title" defaultValue={job.title} name="jobTitle"></Form.Control>
+          <Form.Control required placeholder="Title" defaultValue={job.jobTitle} onSelect={(e)=> onChange(e)} onChange={(e)=> onChange(e)} name="jobTitle">
+          </Form.Control>
         </Form.Group>
 
         <Form.Group className="form-padding">
-          <Form.Control required placeholder="Company" defaultValue={job.company} name="jobCompany"></Form.Control>
+          <Form.Control required placeholder="Company" defaultValue={job.jobCompany} onSelect={(e)=> onChange(e)} onChange={(e)=> onChange(e)} name="jobCompany">
+          </Form.Control>
         </Form.Group>
 
         <Form.Group className="form-padding">
-          <Form.Control placeholder="Location" defaultValue={job.location} name="jobLocation"></Form.Control>
+          <Form.Control placeholder="Location" defaultValue={job.jobLocation} onSelect={(e)=> onChange(e)} onChange={(e)=> onChange(e)} name="jobLocation">
+          </Form.Control>
         </Form.Group>
 
         <Form.Group className="form-padding">
-          <Form.Control placeholder="Link to Application" defaultValue={job.application} name="appLink"></Form.Control>
+          <Form.Control placeholder="Link to Application" defaultValue={job.appLink} onSelect={(e)=> onChange(e)} onChange={(e)=> onChange(e)} name="appLink">
+          </Form.Control>
         </Form.Group>
 
         <Form.Group className="form-padding">
-          <Form.Control required as="select" onChange={(e)=> onChange(e)} aria-label="Default select example" name="type">
-            <option value="" selected disabled>Type: {job.type}</option>
+          <Form.Control as="select" onChange={(e)=> onChange(e)} aria-label="Default select example" name="jobType">
+            <option value="" selected disabled>Type: {job.jobType}</option>
             <option value="INTERNSHIP">INTERNSHIP</option>
             <option value="FULLTIME">FULLTIME</option>
           </Form.Control>
         </Form.Group>
 
         <Form.Group>
-          <Form.Control placeholder="Description: skills, salary, and benefits as applicable" defaultValue={job.description} name="jobDescription"></Form.Control>
+          <Form.Control placeholder="Description: skills, salary, and benefits as applicable" 
+            defaultValue={job.jobDescription} onSelect={(e)=> onChange(e)} onChange={(e)=> onChange(e)} name="jobDescription">
+          </Form.Control>
         </Form.Group>
         <br />
 
         <div style={{ color: "#5dbb79" }}>Dates</div>
         <Form.Group>
-          <Form.Control type="date" placeholder="Applied Date" value={job.applied} name="dateApplied"></Form.Control>
+          <Form.Control type="date" placeholder="Applied Date" value={job.dateApplied} onChange={(e)=> onChange(e)} name="dateApplied">
+          </Form.Control>
         </Form.Group>
         <div className="form-label">Applied Date</div>
 
         <Form.Group>
-          <Form.Control type="date" placeholder="Response Date" value={job.response} name="dateResponse"></Form.Control>
+          <Form.Control type="date" placeholder="Response Date" value={job.dateResponse} onChange={(e)=> onChange(e)} name="dateResponse">
+          </Form.Control>
         </Form.Group>
         <div className="form-label">Response Date</div>
 
         <Form.Group>
-          <Form.Control type="date" placeholder="Interview Date" value={job.interview} name="dateInterview"></Form.Control>
+          <Form.Control type="date" placeholder="Interview Date" value={job.dateInterview} onChange={(e)=> onChange(e)} name="dateInterview">
+          </Form.Control>
         </Form.Group>
         <div className="form-label">Interview Date</div>
 
         <Form.Group>
-          <Form.Control type="date" placeholder="Offer Date" value={job.offer} name="dateOffer"></Form.Control>
+          <Form.Control type="date" placeholder="Offer Date" value={job.dateOffer} onChange={(e)=> onChange(e)} name="dateOffer">
+          </Form.Control>
         </Form.Group>
         <div className="form-label">Offer Date</div>
         <br />
 
         <div style={{ color: "#5dbb79" }}>Process</div>
         <Form.Group className="form-padding">
-          <Form.Control required as="select" onChange={(e)=> onChange(e)} aria-label="Default select example" name="status">
-            <option value="" selected disabled>Status: {job.status}</option>
+          <Form.Control as="select" onChange={(e)=> onChange(e)} aria-label="Default select example" name="appStatus">
+            <option value="" selected disabled>Status: {job.appStatus}</option>
             <option value="APPLIED">APPLIED</option>
             <option value="WAITING">WAITING</option>
             <option value="INTERVIEW SCHEDULED">INTERVIEW SCHEDULED</option>
@@ -131,12 +161,13 @@ function JobDetails() {
         </Form.Group>
 
         <Form.Group className="form-padding">
-          <Form.Control placeholder="Next steps" defaultValue={job.next} name="nextSteps"></Form.Control>
+          <Form.Control placeholder="Next steps" defaultValue={job.nextSteps} onSelect={(e)=> onChange(e)} onChange={(e)=> onChange(e)} name="nextSteps">
+          </Form.Control>
         </Form.Group>
 
-        
         <Form.Group className="form-padding">
-          <Form.Control placeholder="Decision" defaultValue={job.decision} name="decision"></Form.Control>
+          <Form.Control placeholder="Decision" defaultValue={job.decision} onSelect={(e)=> onChange(e)} onChange={(e)=> onChange(e)} name="decision">
+          </Form.Control>
         </Form.Group>
         <br />
 
@@ -154,9 +185,9 @@ function JobDetails() {
         </Form.Group>
         <br /> */}
 
-        <Button type="submit">Add</Button>
+        <Button type="submit">Save</Button>
         <Link to="/job-dashboard">
-          <Button style={{ marginLeft: "0.5rem" }}>Cancel</Button>
+          <Button style={{ marginLeft: "0.5rem" }}>Go Back</Button>
         </Link>
         <br />
         <br />

--- a/client/src/pages/job-dashboard-page/addJob.js
+++ b/client/src/pages/job-dashboard-page/addJob.js
@@ -76,29 +76,34 @@ const AddJob = () => {
 
         <div style={{ color: "#5dbb79" }}>Dates</div>
         <Form.Group>
-          <Form.Control placeholder="Applied Date" name="dateApplied" onChange={onChange}></Form.Control>
+          <Form.Control type="date" placeholder="Applied Date" name="dateApplied" onChange={onChange}></Form.Control>
         </Form.Group>
+        <div className="form-label">Applied Date</div>
 
         <Form.Group>
-          <Form.Control placeholder="Response Date" name="dateResponse" onChange={onChange}></Form.Control>
+          <Form.Control type="date" placeholder="Response Date" name="dateResponse" onChange={onChange}></Form.Control>
         </Form.Group>
+        <div className="form-label">Response Date</div>
 
         <Form.Group>
-          <Form.Control placeholder="Interview Date" name="dateInterview" onChange={onChange}></Form.Control>
+          <Form.Control type="date" placeholder="Interview Date" name="dateInterview" onChange={onChange}></Form.Control>
         </Form.Group>
+        <div className="form-label">Interview Date</div>
 
         <Form.Group>
-          <Form.Control placeholder="Offer Date" name="dateOffer" onChange={onChange}></Form.Control>
+          <Form.Control type="date" placeholder="Offer Date" name="dateOffer" onChange={onChange}></Form.Control>
         </Form.Group>
+        <div className="form-label">Offer Date</div>
         <br />
 
         <div style={{ color: "#5dbb79" }}>Status</div>
         <Form.Group>
           <Form.Control as="select" aria-label="Default select example" name="appStatus" onChange={onChange}>
             <option value="">Status: </option>
-            <option value="Applied">Applied</option>
-            <option value="Waiting">Waiting</option>
-            <option value="Interview Set/Done">Interview Set/Done</option>
+            <option value="APPLIED">APPLIED</option>
+            <option value="WAITING">WAITING</option>
+            <option value="INTERVIEW SCHEDULED">INTERVIEW SCHEDULED</option>
+            <option value="INTERVIEW DONE">INTERVIEW DONE</option>
           </Form.Control>
         </Form.Group>
 
@@ -116,7 +121,7 @@ const AddJob = () => {
         </Form.Group>
         <br />
 
-        <div style={{ color: "#5dbb79" }}>Contact</div>
+        {/* <div style={{ color: "#5dbb79" }}>Contact</div>
         <Form.Group>
           <Form.Control placeholder="Name" name="contactName" onChange={onChange}></Form.Control>
         </Form.Group>
@@ -128,7 +133,7 @@ const AddJob = () => {
         <Form.Group>
           <Form.Control placeholder="Email" name="contactEmail" onChange={onChange}></Form.Control>
         </Form.Group>
-        <br />
+        <br /> */}
 
         <Button type="submit">Add</Button>
         <Link to="/job-dashboard">

--- a/client/src/pages/job-dashboard-page/addJob.js
+++ b/client/src/pages/job-dashboard-page/addJob.js
@@ -97,7 +97,7 @@ const AddJob = () => {
         <div className="form-label">Offer Date</div>
         <br />
 
-        <div style={{ color: "#5dbb79" }}>Status</div>
+        <div style={{ color: "#5dbb79" }}>Process</div>
         <Form.Group className="form-padding">
           <Form.Control as="select" aria-label="Default select example" name="appStatus" onChange={onChange}>
             <option value="">Status: </option>

--- a/client/src/pages/job-dashboard-page/addJob.js
+++ b/client/src/pages/job-dashboard-page/addJob.js
@@ -28,7 +28,7 @@ const AddJob = () => {
         "Authorization": `Bearer ${token}`
       },
       body: JSON.stringify(values)
-    }).then(onSubmitSuccess()).catch(err => console.error(err))
+    }).then(response => onSubmitSuccess(response)).catch(err => console.error(err))
   };
 
   const checkForEmptyFields = () => {
@@ -37,7 +37,8 @@ const AddJob = () => {
     values.jobDescription = (values.jobDescription === undefined) ? '' : values.jobDescription;
   }
 
-  const onSubmitSuccess = () => {
+  const onSubmitSuccess = (response) => {
+    // TO DO: use response and fetch id to POST contact information
     window.location.href = "/job-dashboard"
   }
 
@@ -112,12 +113,7 @@ const AddJob = () => {
         </Form.Group>
 
         <Form.Group>
-          <Form.Control as="select" aria-label="Default select example" name="decision" onChange={onChange}>
-            <option value="">Decision: </option>
-            <option value="Offer">Offer</option>
-            <option value="Rejection">Rejection</option>
-            <option value="N/A">N/A</option>
-          </Form.Control>
+          <Form.Control placeholder="Decision" name="decision" onChange={onChange}></Form.Control>
         </Form.Group>
         <br />
 

--- a/client/src/pages/job-dashboard-page/addJob.js
+++ b/client/src/pages/job-dashboard-page/addJob.js
@@ -46,23 +46,23 @@ const AddJob = () => {
     <div className="add-job-padding">
       <h3 className="jobs-header-2">Add Job</h3>
       <Form onSubmit={onSubmit}>
-        <Form.Group>
+        <Form.Group className="form-padding">
           <Form.Control required placeholder="Title" name="jobTitle" onChange={onChange}></Form.Control>
         </Form.Group>
 
-        <Form.Group>
+        <Form.Group className="form-padding">
           <Form.Control required placeholder="Company" name="jobCompany" onChange={onChange}></Form.Control>
         </Form.Group>
 
-        <Form.Group>
+        <Form.Group className="form-padding">
           <Form.Control placeholder="Location" name="jobLocation" onChange={onChange}></Form.Control>
         </Form.Group>
 
-        <Form.Group>
+        <Form.Group className="form-padding">
           <Form.Control placeholder="Link to Application" name="appLink" onChange={onChange}></Form.Control>
         </Form.Group>
 
-        <Form.Group>
+        <Form.Group className="form-padding">
           <Form.Control required as="select" aria-label="Default select example" name="jobType" onChange={onChange}>
             <option value="">Type: </option>
             <option value="INTERNSHIP">INTERNSHIP</option>
@@ -98,7 +98,7 @@ const AddJob = () => {
         <br />
 
         <div style={{ color: "#5dbb79" }}>Status</div>
-        <Form.Group>
+        <Form.Group className="form-padding">
           <Form.Control as="select" aria-label="Default select example" name="appStatus" onChange={onChange}>
             <option value="">Status: </option>
             <option value="APPLIED">APPLIED</option>
@@ -108,11 +108,11 @@ const AddJob = () => {
           </Form.Control>
         </Form.Group>
 
-        <Form.Group>
+        <Form.Group className="form-padding">
           <Form.Control placeholder="Next steps" name="nextSteps" onChange={onChange}></Form.Control>
         </Form.Group>
 
-        <Form.Group>
+        <Form.Group className="form-padding">
           <Form.Control placeholder="Decision" name="decision" onChange={onChange}></Form.Control>
         </Form.Group>
         <br />

--- a/client/src/pages/job-dashboard-page/addJob.js
+++ b/client/src/pages/job-dashboard-page/addJob.js
@@ -48,19 +48,19 @@ const AddJob = () => {
         <Form.Group>
           <Form.Control required placeholder="Title" name="jobTitle" onChange={onChange}></Form.Control>
         </Form.Group>
-        <br />
+
         <Form.Group>
           <Form.Control required placeholder="Company" name="jobCompany" onChange={onChange}></Form.Control>
         </Form.Group>
-        <br />
+
         <Form.Group>
           <Form.Control placeholder="Location" name="jobLocation" onChange={onChange}></Form.Control>
         </Form.Group>
-        <br />
+
         <Form.Group>
           <Form.Control placeholder="Link to Application" name="appLink" onChange={onChange}></Form.Control>
         </Form.Group>
-        <br />
+
         <Form.Group>
           <Form.Control required as="select" aria-label="Default select example" name="jobType" onChange={onChange}>
             <option value="">Type: </option>
@@ -68,15 +68,74 @@ const AddJob = () => {
             <option value="FULLTIME">FULLTIME</option>
           </Form.Control>
         </Form.Group>
-        <br />
+
         <Form.Group>
           <Form.Control placeholder="Description: skills, salary, and benefits as applicable" name="jobDescription" onChange={onChange}></Form.Control>
         </Form.Group>
         <br />
+
+        <div style={{ color: "#5dbb79" }}>Dates</div>
+        <Form.Group>
+          <Form.Control placeholder="Applied Date" name="dateApplied" onChange={onChange}></Form.Control>
+        </Form.Group>
+
+        <Form.Group>
+          <Form.Control placeholder="Response Date" name="dateResponse" onChange={onChange}></Form.Control>
+        </Form.Group>
+
+        <Form.Group>
+          <Form.Control placeholder="Interview Date" name="dateInterview" onChange={onChange}></Form.Control>
+        </Form.Group>
+
+        <Form.Group>
+          <Form.Control placeholder="Offer Date" name="dateOffer" onChange={onChange}></Form.Control>
+        </Form.Group>
+        <br />
+
+        <div style={{ color: "#5dbb79" }}>Status</div>
+        <Form.Group>
+          <Form.Control as="select" aria-label="Default select example" name="appStatus" onChange={onChange}>
+            <option value="">Status: </option>
+            <option value="Applied">Applied</option>
+            <option value="Waiting">Waiting</option>
+            <option value="Interview Set/Done">Interview Set/Done</option>
+          </Form.Control>
+        </Form.Group>
+
+        <Form.Group>
+          <Form.Control placeholder="Next steps" name="nextSteps" onChange={onChange}></Form.Control>
+        </Form.Group>
+
+        <Form.Group>
+          <Form.Control as="select" aria-label="Default select example" name="decision" onChange={onChange}>
+            <option value="">Decision: </option>
+            <option value="Offer">Offer</option>
+            <option value="Rejection">Rejection</option>
+            <option value="N/A">N/A</option>
+          </Form.Control>
+        </Form.Group>
+        <br />
+
+        <div style={{ color: "#5dbb79" }}>Contact</div>
+        <Form.Group>
+          <Form.Control placeholder="Name" name="contactName" onChange={onChange}></Form.Control>
+        </Form.Group>
+
+        <Form.Group>
+          <Form.Control placeholder="Phone" name="contactPhone" onChange={onChange}></Form.Control>
+        </Form.Group>
+
+        <Form.Group>
+          <Form.Control placeholder="Email" name="contactEmail" onChange={onChange}></Form.Control>
+        </Form.Group>
+        <br />
+
         <Button type="submit">Add</Button>
         <Link to="/job-dashboard">
           <Button style={{ marginLeft: "0.5rem" }}>Cancel</Button>
         </Link>
+        <br />
+        <br />
       </Form>
     </div>
   );


### PR DESCRIPTION
**/add-job**
- Now includes fields for dates and status to be added

**/job-dashboard/:job-id**
- Opted for a details page for each job instead of my previous idea of expanding each row in the job dashboard table
- Can click on the `More` button on each row in the job dashboard to view all information about the particular job
- Can view and `Go Back` to the dashboard, or edit information and `Save` to the database.

**Upcoming changes**
- I will work on adding the Contact information next, similarly to the changes made in this PR.

**Screenshots**
- Form for adding job:
![image](https://user-images.githubusercontent.com/61304376/169629832-2e5bd8c3-8e7b-43e4-90b8-796c9a6b365e.png)

- Job dashboard with `More` button:
![image](https://user-images.githubusercontent.com/61304376/169629843-acaaa9c8-1e1c-46e9-a29e-0977aad27985.png)

- Job details page to view/edit jobs:
![image](https://user-images.githubusercontent.com/61304376/169629860-990d49ca-fc3b-4d99-b671-4e72465e8e47.png)
